### PR TITLE
This is an incomplete example, but hopefully useful:

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -45,7 +45,7 @@ component 'cpp-hocon' do |pkg, settings, platform|
 
     cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
     toolchain = '-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake'
     cmake = '/opt/pl-build-tools/bin/cmake'
   elsif platform.is_aix?

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -59,7 +59,7 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
 
     cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
     # use default that is pl-build-tools
   else
     # These platforms use the default OS toolchain, rather than pl-build-tools

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -59,7 +59,10 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
 
     cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
+  elsif platform.name == 'sles-11-x86_64'
+    cmake = 'env LD_LIBRARY_PATH=/opt/pl-build-tools/lib64 /opt/pl-build-tools/bin/cmake'
+    special_flags = " -DCMAKE_CXX_FLAGS='-Wno-error=implicit-fallthrough -Wno-error=catch-value' "
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
     # use default that is pl-build-tools
   else
     # These platforms use the default OS toolchain, rather than pl-build-tools

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -20,7 +20,7 @@ component 'leatherman' do |pkg, settings, platform|
   elsif platform.is_windows?
     pkg.build_requires 'cmake'
     pkg.build_requires "pl-gettext-#{platform.architecture}"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
     pkg.build_requires 'pl-cmake'
     pkg.build_requires 'pl-gettext'
     pkg.build_requires 'runtime'
@@ -90,7 +90,7 @@ component 'leatherman' do |pkg, settings, platform|
 
     # Use environment variable set in environment.bat to find locale files
     leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PUPPET_DIR' -DLEATHERMAN_LOCALE_INSTALL='share/locale'"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
     toolchain = '-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake'
     cmake = '/opt/pl-build-tools/bin/cmake'
     special_flags += " -DCMAKE_CXX_FLAGS='-Wno-deprecated-declarations' "

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -20,7 +20,11 @@ component 'leatherman' do |pkg, settings, platform|
   elsif platform.is_windows?
     pkg.build_requires 'cmake'
     pkg.build_requires "pl-gettext-#{platform.architecture}"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
+  elsif platform.name == 'sles-11-x86_64'
+    pkg.build_requires 'pl-cmake'
+    pkg.build_requires 'pl-gettext'
+    pkg.build_requires 'runtime'
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
     pkg.build_requires 'pl-cmake'
     pkg.build_requires 'pl-gettext'
     pkg.build_requires 'runtime'
@@ -90,7 +94,11 @@ component 'leatherman' do |pkg, settings, platform|
 
     # Use environment variable set in environment.bat to find locale files
     leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PUPPET_DIR' -DLEATHERMAN_LOCALE_INSTALL='share/locale'"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
+  elsif platform.name == 'sles-11-x86_64'
+    cmake = 'env LD_LIBRARY_PATH=/opt/pl-build-tools/lib64 /opt/pl-build-tools/bin/cmake'
+    toolchain = '-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake'
+    special_flags += " -DCMAKE_CXX_FLAGS='-Wno-deprecated-declarations -Wno-error=class-memaccess -Wno-error=ignored-qualifiers -Wno-error=catch-value' "
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
     toolchain = '-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake'
     cmake = '/opt/pl-build-tools/bin/cmake'
     special_flags += " -DCMAKE_CXX_FLAGS='-Wno-deprecated-declarations' "
@@ -149,8 +157,10 @@ component 'leatherman' do |pkg, settings, platform|
     test_locale = 'LANG=C LC_ALL=C' if platform.is_solaris? || platform.name =~ /debian-10/
 
     pkg.check do
+      ## LD_LIBRARY_PATH hardwired for demonstration. Likely needs to be converted to
+      ## a variable for the various platform support.
       ["LEATHERMAN_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') \
-       LD_LIBRARY_PATH=#{settings[:libdir]} LIBPATH=#{settings[:libdir]} #{test_locale} #{make} test ARGS=-V"]
+       LD_LIBRARY_PATH=/opt/pl-build-tools/lib64 LIBPATH=#{settings[:libdir]} #{test_locale} #{make} test ARGS=-V"]
     end
   end
 

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -73,7 +73,7 @@ component 'pxp-agent' do |pkg, settings, platform|
     cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
 
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
     # use default that is pl-build-tools
   else
     # These platforms use the default OS toolchain, rather than pl-build-tools

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -12,7 +12,7 @@ component 'runtime' do |pkg, _settings, platform|
     pkg.build_requires "pl-iconv-#{platform.architecture}"
     pkg.build_requires "pl-libffi-#{platform.architecture}"
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
     pkg.build_requires 'pl-gcc'
   end
 end

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -12,7 +12,9 @@ component 'runtime' do |pkg, _settings, platform|
     pkg.build_requires "pl-iconv-#{platform.architecture}"
     pkg.build_requires "pl-libffi-#{platform.architecture}"
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
+  elsif platform.name = 'sles-11-x86_64'
+    pkg.build_requires 'pl-gcc8'
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
     pkg.build_requires 'pl-gcc'
   end
 end

--- a/configs/platforms/sles-11-x86_64.rb
+++ b/configs/platforms/sles-11-x86_64.rb
@@ -3,8 +3,8 @@ platform "sles-11-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
 
-  # plat.add_build_repository "http://osmirror.delivery.puppetlabs.net/sles-11-deps-x86_64/sles-11-deps-x86_64.repo"
-  # plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/11/x86_64/pl-build-tools-sles-11-x86_64.repo"
+  plat.add_build_repository "http://osmirror.delivery.puppetlabs.net/sles-11-deps-x86_64/sles-11-deps-x86_64.repo"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/11/x86_64/pl-build-tools-sles-11-x86_64.repo"
   packages = %w[
     aaa_base
     libbz2-devel
@@ -18,6 +18,5 @@ platform "sles-11-x86_64" do |plat|
   ]
   plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
   plat.provision_with("zypper -n --no-gpg-checks install -y #{packages.join(' ')}")
-  # plat.provision_with "zypper install -y --oldpackage pl-cmake-3.2.3-13.sles11.x86_64"
   plat.vmpooler_template "sles-11-x86_64"
 end

--- a/configs/platforms/sles-11-x86_64.rb
+++ b/configs/platforms/sles-11-x86_64.rb
@@ -1,0 +1,23 @@
+platform "sles-11-x86_64" do |plat|
+  plat.servicedir "/etc/init.d"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "sysv"
+
+  # plat.add_build_repository "http://osmirror.delivery.puppetlabs.net/sles-11-deps-x86_64/sles-11-deps-x86_64.repo"
+  # plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/11/x86_64/pl-build-tools-sles-11-x86_64.repo"
+  packages = %w[
+    aaa_base
+    libbz2-devel
+    make
+    pkgconfig
+    pl-autotools
+    pl-cmake
+    readline-devel
+    rsync
+    zlib-devel
+  ]
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
+  plat.provision_with("zypper -n --no-gpg-checks install -y #{packages.join(' ')}")
+  # plat.provision_with "zypper install -y --oldpackage pl-cmake-3.2.3-13.sles11.x86_64"
+  plat.vmpooler_template "sles-11-x86_64"
+end

--- a/configs/projects/pxp-agent.rb
+++ b/configs/projects/pxp-agent.rb
@@ -31,7 +31,7 @@ project 'pxp-agent' do |proj|
 
   proj.component 'pl-cmake-patch'
   proj.component 'puppet-runtime'
-  proj.component 'runtime' if platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/ || !platform.is_linux?
+  proj.component 'runtime' if platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/ || !platform.is_linux?
 
   proj.component 'leatherman'
   proj.component 'cpp-hocon'


### PR DESCRIPTION
Briefly:

  - Standardize on GCC8
  - Make SLES-11 its own case rather than clumping with other old platforms

Still needs work:

  - Sort out some hardwires (like in leatherman pkg.test) that I made in haste.
  - Set more 'no-error' flags as needed.
  - Be more consistent with LD_LIBRARY_PATH

Eventually:

  - Modify the code so that the warnings aren't thrown.